### PR TITLE
Allow overriding config.yml file via env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Additionally, the following environment variables can be defined
 
 -	SERVICE_PORT - what port to run the service (if you don't like 5556)
 -	JVM_OPTS - any additional options, Xmx etc.
+-   CONFIG_YML - override the location of config.yaml (default: /opt/jmx_exporter/config.yml which monitors jmx exporter's jvm)
 
 Using with Prometheus
 ---------------------

--- a/start.sh
+++ b/start.sh
@@ -8,5 +8,8 @@ if [ -z "$JVM_OPTS" ]; then
   JVM_OPTS="-Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.port=5555"
 fi
 
-java $JVM_OPTS -jar /opt/jmx_exporter/jmx_prometheus_httpserver-$VERSION-jar-with-dependencies.jar $SERVICE_PORT /opt/jmx_exporter/config.yml
+if [ -z "$CONFIG_YML" ]; then
+  CONFIG_YML=/opt/jmx_exporter/config.yml
+fi
 
+java $JVM_OPTS -jar /opt/jmx_exporter/jmx_prometheus_httpserver-$VERSION-jar-with-dependencies.jar $SERVICE_PORT $CONFIG_YML


### PR DESCRIPTION
I'm trying to use this docker image in K8s and in order to change the config file I was trying to mount a configmap.  But the configmap path is the same folder as were the jar and start.sh are located, so that doesn't work well.

If I could override the location of the config.yml file it would make things cleaner/simpler in Kubernetes.